### PR TITLE
Decouple Performance Metrics from Execution Strategy via Template Method Pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,223 @@
+# Transformer Inference Engine
+
+A from-scratch GPT-2 inference engine written in C++/CUDA, purpose-built to maximize token throughput on a **single NVIDIA GTX 1050 Ti** (4GB VRAM, 768 CUDA cores, Pascal SM 6.1).
+
+**Goal:** Beat vLLM and standard inference libraries on next-token prediction latency and throughput for GPT-2 (124M) — on consumer-grade hardware that the big frameworks ignore.
+
+## Why This Exists
+
+Production inference frameworks (vLLM, TensorRT-LLM, etc.) are designed for data-center GPUs with 40-80GB of VRAM. They carry overhead — Python runtime, generic kernels, PagedAttention for multi-tenant serving — that makes no sense on a 4GB card.
+
+This engine takes the opposite approach: every CUDA kernel, every memory allocation, and every architectural decision is hand-tuned for the constraints of a GTX 1050 Ti. No framework overhead. No Python in the hot path. Just C++ and raw CUDA.
+
+## Current Performance
+
+**GPU:** NVIDIA GeForce GTX 1050 Ti (4040 MB VRAM, 6 SMs, Compute Capability 6.1)
+**Model:** GPT-2 Small (124M parameters, 12 layers, 768 dim, 12 heads)
+
+| Metric | Current |
+|---|---|
+| **Prefill Throughput** | ~200-600 tok/s |
+| **Decode Throughput** | ~27-31 tok/s |
+| **TTFT (4 tokens)** | ~15 ms |
+| **Weight Memory** | 622 MB / 632 MB (98.4%) |
+| **Scratch Memory** | 1136 MB |
+
+> These numbers are from the built-in benchmark suite running real text prompts. Decode throughput is currently without KV cache — every token recomputes the full sequence attention. This is the primary optimization target.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                    Client Code (main.cpp)                     │
+│                  Submits prompts, reads results               │
+└──────────────────────┬───────────────────────────────────────┘
+                       │
+                       ▼
+┌──────────────────────────────────────────────────────────────┐
+│              BatchExecutorOrchestrator                        │
+│  Owns: Transformer model, weights arena, tokenizer           │
+│  Creates BatchExecutors per request with isolated memory     │
+└──────────────────────┬───────────────────────────────────────┘
+                       │
+                       ▼
+┌──────────────────────────────────────────────────────────────┐
+│                    BatchExecutor                              │
+│  Owns: CUDA stream, scratch memory arena                     │
+│  Delegates to: ExecutionStrategy (via polymorphism)           │
+└──────────────────────┬───────────────────────────────────────┘
+                       │
+                       ▼
+┌──────────────────────────────────────────────────────────────┐
+│              ExecutionStrategy (Template Method)              │
+│                                                              │
+│  generate() {                                                │
+│      prefill_time = time( run_prefill() )  ← defined once    │
+│      decode_time  = time( run_decode()  )  ← defined once    │
+│      compute metrics (tok/s, latency)      ← defined once    │
+│  }                                                           │
+│                                                              │
+│  Concrete strategies only implement:                         │
+│    run_prefill()  — process prompt, emit first token          │
+│    run_decode()   — autoregressive token generation loop      │
+│    finalize()     — detokenization                            │
+└──────────────────────┬───────────────────────────────────────┘
+                       │
+              ┌────────┴──────────┐
+              ▼                   ▼
+     PipelineEngine        (Future: KVCacheEngine,
+     (current impl)         FusedKernelEngine, ...)
+```
+
+### Key Design Decisions
+
+- **Arena-based GPU memory management** — Pre-allocates bulk GPU memory and sub-allocates from it. No `cudaMalloc` in the hot path. Scratch memory is reset per-token via offset tracking.
+- **Strategy pattern for execution** — The `ExecutionStrategy` base class enforces consistent metric definitions (what "prefill time" and "decode time" mean) across all strategies via the Template Method pattern. New strategies implement execution logic; the framework handles timing.
+- **Stream-per-executor isolation** — Each `BatchExecutor` gets its own CUDA stream and memory arena, enabling concurrent execution without resource conflicts.
+- **All custom CUDA kernels** — No cuBLAS, no cuDNN. Every kernel (GEMM, softmax, LayerNorm, attention, GELU, argmax) is hand-written and tuned for this GPU's constraints.
+
+## Project Structure
+
+```
+├── include/
+│   ├── pipeline/
+│   │   ├── execution_strategy.hpp  # Abstract base — Template Method pattern
+│   │   ├── pipeline_engine.hpp     # Current execution strategy
+│   │   └── metrics.hpp             # GenerationMetrics, GenerationResult, GenerationConfig
+│   ├── layers/
+│   │   ├── transformer.h           # Transformer, TransformerBlock, LayerNorm, FeedForward
+│   │   └── attention.h             # Multi-head self-attention
+│   ├── batch_executor.hpp          # Per-batch execution context (stream + memory)
+│   ├── batch_executor_orchestrator.hpp  # Top-level API — model + weight lifecycle
+│   ├── kernels.cuh                 # All CUDA kernel declarations
+│   ├── memory.h                    # GPUMemoryArena (bump allocator)
+│   ├── tokenizer.h                 # BPE tokenizer (GPT-2 compatible)
+│   └── model_config.hpp            # Hyperparameter struct
+├── src/
+│   ├── kernels/                    # CUDA kernel implementations
+│   │   ├── gemm.cu                 #   Tiled GEMM
+│   │   ├── batched_gemm.cu         #   Batched GEMM (attention scores)
+│   │   ├── softmax.cu              #   Numerically stable softmax
+│   │   ├── layernorm.cu            #   Warp-intrinsic LayerNorm
+│   │   ├── embedding.cu            #   Token + positional embedding lookup
+│   │   ├── activation.cu           #   Fused bias + GELU
+│   │   ├── sampling.cu             #   Argmax (greedy decoding)
+│   │   ├── transpose.cu            #   Matrix transpose
+│   │   ├── addition.cu             #   Element-wise addition (residuals)
+│   │   └── ...
+│   ├── layers/                     # C++ layer implementations
+│   │   ├── attention.cpp           #   Multi-head attention orchestration
+│   │   ├── feed_forward.cpp        #   FFN (up-proj → GELU → down-proj)
+│   │   ├── layer_norm.cpp          #   LayerNorm wrapper
+│   │   └── transformer_block.cpp   #   Pre-norm transformer block
+│   ├── pipeline/
+│   │   └── pipeline_engine.cpp     # PipelineEngine strategy implementation
+│   ├── transformer.cpp             # Full forward pass orchestration
+│   ├── batch_executor.cpp          # BatchExecutor implementation
+│   ├── batch_executor_orchestrator.cpp
+│   ├── tokenizer.cpp               # BPE encode/decode
+│   ├── memory.cpp                  # GPU arena allocator
+│   └── main.cpp                    # CLI entry point
+├── tests/
+│   ├── bench_performance.cu        # Full benchmark suite (kernels + pipeline)
+│   ├── test_transformer.cu         # End-to-end transformer correctness
+│   ├── test_attention.cu           # Attention layer tests
+│   ├── test_feed_forward.cu        # FFN tests
+│   ├── test_gemm.cu                # GEMM correctness
+│   └── ...                         # Per-kernel unit tests
+├── tools/
+│   ├── gpt2_exporter.py            # Export HuggingFace GPT-2 weights to binary
+│   ├── hf_baseline.py              # HuggingFace reference for comparison
+│   └── ...                         # Debug/validation scripts
+├── docs/
+│   └── performance_testing/        # Timestamped benchmark reports (CSV + summary)
+├── dataset/
+│   ├── input/                      # Benchmark prompt files
+│   └── output/                     # Generated text per run
+└── CMakeLists.txt
+```
+
+## Building
+
+### Prerequisites
+
+- CUDA Toolkit (tested with CUDA 12.x)
+- CMake ≥ 3.18
+- C++17 compiler
+- NVIDIA GPU with Compute Capability ≥ 6.1
+
+### Setup
+
+```bash
+# 1. Clone and enter
+git clone <repo-url>
+cd transformer_inference_engine
+
+# 2. Export GPT-2 weights (requires Python + transformers)
+python tools/gpt2_exporter.py
+
+# 3. Build
+mkdir -p build && cd build
+cmake -DCMAKE_CUDA_ARCHITECTURES=61 ..
+make -j$(nproc)
+```
+
+### Run
+
+```bash
+# Run inference
+./gpt2_engine
+
+# Run full benchmark suite
+./bench_performance
+
+# Run individual tests
+./test_transformer
+./test_attention
+./test_gemm
+# ... etc
+```
+
+### Example Output
+
+```
+>>> Initializing Engine...
+>>> Starting Inference: 'Alan Turing was a' ...
+ brilliant mathematician, and he was a great friend of mine.
+
+--- Performance Metrics ---
+Prefill Time:  18.29 ms (218.68 tok/s)
+Decode Time:   392.78 ms (48.37 tok/s) for 19 tokens
+Total Time:    411.07 ms
+```
+
+## Benchmark Suite
+
+The benchmark (`tests/bench_performance.cu`) runs two tiers:
+
+1. **Kernel-level** — Isolated timing of individual CUDA kernels (embedding lookup, GEMM, attention QK, softmax, LayerNorm) across different sequence lengths.
+2. **Pipeline-level** — End-to-end generation from real text prompts with prefill/decode throughput measurement.
+
+Reports are saved to `docs/performance_testing/run_<timestamp>/` as CSV + human-readable summary.
+
+```bash
+# Run benchmarks
+cd build && ./bench_performance
+
+# View latest report
+cat docs/performance_testing/run_*/summary_*.txt
+```
+
+## Roadmap
+
+The primary bottleneck is decode throughput (~30 tok/s). Key optimizations planned:
+
+- [ ] **KV Cache** — Avoid recomputing attention over the full sequence at each decode step. This is the single biggest win available.
+- [ ] **Kernel Fusion** — Fuse LayerNorm + QKV projection, bias + GELU, and other adjacent operations to reduce memory bandwidth pressure and kernel launch overhead.
+- [ ] **Memory-Efficient Attention** — Reduce the O(S²) attention memory footprint to enable longer sequences within 4GB VRAM.
+- [ ] **FP16 / INT8 Quantization** — Halve memory usage and leverage Pascal's FP16 throughput (with caveats — GTX 1050 Ti has limited FP16 support).
+- [ ] **CUDA Graphs** — Capture the decode loop as a graph to eliminate per-step kernel launch overhead.
+
+## License
+
+This project is for educational and research purposes.

--- a/include/batch_executor.hpp
+++ b/include/batch_executor.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "pipeline/execution_strategy.hpp"
 #include "pipeline/pipeline_engine.hpp"
 #include "memory.h"
 #include <vector>
@@ -36,7 +37,7 @@ private:
     cudaStream_t stream;
     std::unique_ptr<GPUMemoryArena> inference_arena;
     
-    // The specific strategy
+    // The specific strategy — stored as base class pointer
     StrategyType strategy_type;
-    std::unique_ptr<pipeline::PipelineEngine> strategy;
+    std::unique_ptr<pipeline::ExecutionStrategy> strategy;
 };

--- a/include/pipeline/execution_strategy.hpp
+++ b/include/pipeline/execution_strategy.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "pipeline/metrics.hpp"
+#include "memory.h"
+#include <vector>
+#include <cuda_runtime.h>
+
+namespace pipeline {
+
+// Abstract base class for execution strategies.
+//
+// Uses the Template Method pattern: generate() defines the execution skeleton
+// and owns all timing/metrics computation. Subclasses implement the pure
+// virtual hooks (run_prefill, run_decode, finalize) without any awareness
+// of timing or metrics — guaranteeing consistent metric definitions across
+// all strategies.
+class ExecutionStrategy {
+public:
+    virtual ~ExecutionStrategy() = default;
+
+    // Template method — NOT virtual. This is the single entry point.
+    // Defines what "prefill time" and "decode time" mean structurally.
+    GenerationResult generate(const std::vector<int>& input_ids, const GenerationConfig& config) {
+        GenerationResult result;
+        result.output_sequence = input_ids;
+        result.metrics.prompt_tokens = input_ids.size();
+
+        // ---- PREFILL: base class defines and times this phase ----
+        result.metrics.prefill_time_ms = time_cuda_execution([&]() {
+            run_prefill(result, config);
+        });
+
+        // ---- DECODE: base class defines and times this phase ----
+        result.metrics.decode_time_ms = time_cuda_execution([&]() {
+            run_decode(result, config);
+        });
+
+        // ---- METRICS: computed once, consistently, for all strategies ----
+        result.metrics.total_time_ms = result.metrics.prefill_time_ms 
+                                     + result.metrics.decode_time_ms;
+
+        result.metrics.prefill_tokens_per_sec = 
+            result.metrics.prompt_tokens / (result.metrics.prefill_time_ms / 1000.0);
+
+        double decode_time_sec = result.metrics.decode_time_ms / 1000.0;
+        if (result.metrics.generated_tokens > 1) {
+            // generated_tokens includes the 1 token from prefill
+            result.metrics.decode_tokens_per_sec = 
+                (result.metrics.generated_tokens - 1) / decode_time_sec;
+        } else {
+            result.metrics.decode_tokens_per_sec = 0.0;
+        }
+
+        // ---- FINALIZE: strategy-specific post-processing (e.g., detokenize) ----
+        finalize(result);
+
+        return result;
+    }
+
+protected:
+    // Strategies implement ONLY these — no timing, no metric math.
+
+    // Process the full prompt and produce the first new token.
+    virtual void run_prefill(GenerationResult& result, const GenerationConfig& config) = 0;
+
+    // Generate remaining tokens autoregressively.
+    virtual void run_decode(GenerationResult& result, const GenerationConfig& config) = 0;
+
+    // Post-processing (e.g., decode token IDs to text).
+    virtual void finalize(GenerationResult& result) = 0;
+
+    // Subclasses must provide access to their CUDA stream for timing.
+    virtual cudaStream_t get_stream() const = 0;
+
+private:
+    // Precise GPU timing via CUDA events — used only by the base class.
+    template <typename F>
+    double time_cuda_execution(F&& func) {
+        cudaStream_t s = get_stream();
+
+        cudaEvent_t start, stop;
+        cudaEventCreate(&start);
+        cudaEventCreate(&stop);
+
+        cudaEventRecord(start, s);
+        func();
+        cudaEventRecord(stop, s);
+        cudaEventSynchronize(stop);
+
+        float ms = 0.0f;
+        cudaEventElapsedTime(&ms, start, stop);
+
+        cudaEventDestroy(start);
+        cudaEventDestroy(stop);
+
+        return static_cast<double>(ms);
+    }
+};
+
+} // namespace pipeline

--- a/include/pipeline/pipeline_engine.hpp
+++ b/include/pipeline/pipeline_engine.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "pipeline/metrics.hpp"
+#include "pipeline/execution_strategy.hpp"
 #include "transformer.h"
 #include "tokenizer.h"
 #include "memory.h"
@@ -8,13 +8,17 @@
 
 namespace pipeline {
 
-class PipelineEngine {
+class PipelineEngine : public ExecutionStrategy {
 public:
     PipelineEngine(Transformer& model, GPT2Tokenizer& tokenizer, GPUMemoryArena& inference_arena, cudaStream_t stream = 0);
 
-    // Main entry point for generating tokens.
-    // Handles memory updates, loops, and accurately times execution.
-    GenerationResult generate(const std::vector<int>& input_ids, const GenerationConfig& config);
+protected:
+    // Strategy hooks — pure execution logic, no timing, no metric math.
+    void run_prefill(GenerationResult& result, const GenerationConfig& config) override;
+    void run_decode(GenerationResult& result, const GenerationConfig& config) override;
+    void finalize(GenerationResult& result) override;
+
+    cudaStream_t get_stream() const override { return stream; }
 
 private:
     Transformer& model;
@@ -27,10 +31,6 @@ private:
     float* d_logits;
     int* d_next_token;
     size_t persistent_offset;
-
-    // Helper to time a lambda execution via CUDA events
-    template <typename F>
-    double time_cuda_execution(F&& func);
 };
 
 } // namespace pipeline

--- a/src/pipeline/pipeline_engine.cpp
+++ b/src/pipeline/pipeline_engine.cpp
@@ -1,6 +1,5 @@
 #include "pipeline/pipeline_engine.hpp"
 #include <iostream>
-#include <chrono>
 
 namespace pipeline {
 
@@ -18,106 +17,65 @@ PipelineEngine::PipelineEngine(Transformer& model, GPT2Tokenizer& tokenizer, GPU
     persistent_offset = inference_arena.get_user();
 }
 
-template <typename F>
-double PipelineEngine::time_cuda_execution(F&& func) {
-    cudaEvent_t start, stop;
-    cudaEventCreate(&start);
-    cudaEventCreate(&stop);
-
-    cudaEventRecord(start, stream);
-    func();
-    cudaEventRecord(stop, stream);
-    cudaEventSynchronize(stop);
-
-    float ms = 0.0f;
-    cudaEventElapsedTime(&ms, start, stop);
-
-    cudaEventDestroy(start);
-    cudaEventDestroy(stop);
-
-    return static_cast<double>(ms);
-}
-
-GenerationResult PipelineEngine::generate(const std::vector<int>& input_ids, const GenerationConfig& config) {
-    GenerationResult result;
-    result.output_sequence = input_ids;
-    result.metrics.prompt_tokens = input_ids.size();
-    
+void PipelineEngine::run_prefill(GenerationResult& result, const GenerationConfig& config) {
     int vocab_size = model.get_vocab_size();
     int max_seq_len = model.get_max_seq_len();
-    int max_new_tokens = config.max_new_tokens;
+    int current_seq_len = result.output_sequence.size();
 
-    // Fast fail check
-    if (input_ids.size() + max_new_tokens > max_seq_len) {
-        std::cerr << "Warning: Generation length exceeds maximum sequence length!" << std::endl;
-        max_new_tokens = max_seq_len - input_ids.size();
-    }
+    inference_arena.reset_to(persistent_offset);
 
-    // PHASE 1: PREFILL (First token)
-    // Even without KV cache, we time the first forward pass separately as PREFILL
-    result.metrics.prefill_time_ms = time_cuda_execution([&]() {
-        int current_seq_len = result.output_sequence.size();
-        inference_arena.reset_to(persistent_offset);
-        
-        cudaMemcpyAsync(d_input_ids, result.output_sequence.data(), current_seq_len * sizeof(int), cudaMemcpyHostToDevice, stream);
-        
-        model.forward(d_input_ids, d_logits, 1, current_seq_len, inference_arena, stream);
-        
-        float* last_logits = d_logits + (current_seq_len - 1) * vocab_size;
-        kernels::launch_argmax(last_logits, d_next_token, 1, 1, vocab_size, stream);
-    });
+    cudaMemcpyAsync(d_input_ids, result.output_sequence.data(), current_seq_len * sizeof(int), cudaMemcpyHostToDevice, stream);
+
+    model.forward(d_input_ids, d_logits, 1, current_seq_len, inference_arena, stream);
+
+    float* last_logits = d_logits + (current_seq_len - 1) * vocab_size;
+    kernels::launch_argmax(last_logits, d_next_token, 1, 1, vocab_size, stream);
 
     int next_token_id;
     cudaMemcpyAsync(&next_token_id, d_next_token, sizeof(int), cudaMemcpyDeviceToHost, stream);
     cudaStreamSynchronize(stream);
-    
+
     result.output_sequence.push_back(next_token_id);
     result.metrics.generated_tokens++;
+}
 
-    // PHASE 2: DECODE
-    result.metrics.decode_time_ms = time_cuda_execution([&]() {
-        for (int step = 1; step < max_new_tokens; ++step) {
-            int current_seq_len = result.output_sequence.size();
-            
-            // Re-use scratch memory for each token
-            inference_arena.reset_to(persistent_offset);
-            
-            cudaMemcpyAsync(d_input_ids, result.output_sequence.data(), current_seq_len * sizeof(int), cudaMemcpyHostToDevice, stream);
-            
-            model.forward(d_input_ids, d_logits, 1, current_seq_len, inference_arena, stream);
-            
-            float* last_logits = d_logits + (current_seq_len - 1) * vocab_size;
-            kernels::launch_argmax(last_logits, d_next_token, 1, 1, vocab_size, stream);
-            
-            int token;
-            cudaMemcpyAsync(&token, d_next_token, sizeof(int), cudaMemcpyDeviceToHost, stream);
-            cudaStreamSynchronize(stream);
-            
-            result.output_sequence.push_back(token);
-            result.metrics.generated_tokens++;
-        }
-    });
+void PipelineEngine::run_decode(GenerationResult& result, const GenerationConfig& config) {
+    int vocab_size = model.get_vocab_size();
+    int max_seq_len = model.get_max_seq_len();
+    int max_new_tokens = config.max_new_tokens;
 
-    // Populate Metrics
-    result.metrics.total_time_ms = result.metrics.prefill_time_ms + result.metrics.decode_time_ms;
-    
-    // Throughput (assuming prefill processes N prompt tokens, and decode generates M new tokens)
-    result.metrics.prefill_tokens_per_sec = (result.metrics.prompt_tokens / (result.metrics.prefill_time_ms / 1000.0));
-    
-    double decode_time_sec = result.metrics.decode_time_ms / 1000.0;
-    // We generated (max_new_tokens - 1) tokens during the decode phase timed block
-    if (result.metrics.generated_tokens > 1) {
-        result.metrics.decode_tokens_per_sec = ((result.metrics.generated_tokens - 1) / decode_time_sec);
-    } else {
-        result.metrics.decode_tokens_per_sec = 0.0;
+    // Cap generation length
+    if (result.output_sequence.size() + (max_new_tokens - 1) > max_seq_len) {
+        std::cerr << "Warning: Generation length exceeds maximum sequence length!" << std::endl;
+        max_new_tokens = max_seq_len - result.output_sequence.size() + 1;
     }
 
-    // Un-tokenize
-    // We only extract the newly generated tokens
+    for (int step = 1; step < max_new_tokens; ++step) {
+        int current_seq_len = result.output_sequence.size();
+
+        // Re-use scratch memory for each token
+        inference_arena.reset_to(persistent_offset);
+
+        cudaMemcpyAsync(d_input_ids, result.output_sequence.data(), current_seq_len * sizeof(int), cudaMemcpyHostToDevice, stream);
+
+        model.forward(d_input_ids, d_logits, 1, current_seq_len, inference_arena, stream);
+
+        float* last_logits = d_logits + (current_seq_len - 1) * vocab_size;
+        kernels::launch_argmax(last_logits, d_next_token, 1, 1, vocab_size, stream);
+
+        int token;
+        cudaMemcpyAsync(&token, d_next_token, sizeof(int), cudaMemcpyDeviceToHost, stream);
+        cudaStreamSynchronize(stream);
+
+        result.output_sequence.push_back(token);
+        result.metrics.generated_tokens++;
+    }
+}
+
+void PipelineEngine::finalize(GenerationResult& result) {
+    // Decode only the newly generated tokens
     std::vector<int> new_tokens(result.output_sequence.begin() + result.metrics.prompt_tokens, result.output_sequence.end());
-    result.decoded_text = tokenizer.decode(new_tokens); // Returns the newly generated text
-    
-    return result;
+    result.decoded_text = tokenizer.decode(new_tokens);
 }
 
 } // namespace pipeline


### PR DESCRIPTION


### Summary

Introduces an `ExecutionStrategy` abstract base class that separates **what to time** from **how to execute**, ensuring consistent metric definitions across all current and future execution strategies. Also adds a comprehensive project README.

### Problem

Performance metrics (prefill time, decode throughput, etc.) were calculated **inside** `PipelineEngine::generate()`. This created three problems:

1. **Timing was strategy-owned** — `PipelineEngine` decided what to time and how, meaning a future strategy (e.g., KV cache) would need to reimplement all timing logic.
2. **Metric formulas were embedded in execution code** — tokens/sec calculations were hardcoded alongside CUDA kernels, coupling concerns that should be independent.
3. **No guarantee of semantic consistency** — if two strategies both report "prefill_time_ms", nothing enforced that they measured the same thing.

### Solution

**Template Method pattern** — the base class `ExecutionStrategy` owns `generate()` and defines the execution skeleton:

```
generate() {
    prefill_time = time( run_prefill() )   ← base class defines & times
    decode_time  = time( run_decode()  )   ← base class defines & times
    compute tok/s, total_time              ← base class computes once
    finalize()                             ← strategy detokenizes
}
```

Strategies only implement `run_prefill()`, `run_decode()`, and `finalize()` — they never touch a timer or compute a metric. This **structurally guarantees** that "prefill time" means the same thing for every strategy.

### Changes

| File | Change |
|---|---|
| `include/pipeline/execution_strategy.hpp` | **NEW** — Abstract base class with Template Method. Owns `generate()`, `time_cuda_execution()`, and all metric computation. |
| `include/pipeline/pipeline_engine.hpp` | Inherits from `ExecutionStrategy`. Exposes `run_prefill()`, `run_decode()`, `finalize()` as protected overrides. Removed `generate()` and `time_cuda_execution()`. |
| `src/pipeline/pipeline_engine.cpp` | Split monolithic `generate()` into three focused hooks with pure execution logic — no timing, no metric math. |
| `include/batch_executor.hpp` | Strategy member changed from `unique_ptr<PipelineEngine>` to `unique_ptr<ExecutionStrategy>`. |
| `README.md` | **NEW** — Comprehensive project documentation. |

### What Did NOT Change (by design)

- `bench_performance.cu` — zero changes, reads `result.metrics` as before
- `main.cpp` — zero changes
- `batch_executor.cpp` — zero changes (polymorphism handles it)
- `batch_executor_orchestrator.*` — zero changes
- `metrics.hpp` — zero changes

### How to Add a New Strategy After This PR

```cpp
class KVCacheEngine : public pipeline::ExecutionStrategy {
protected:
    void run_prefill(...) override { /* your prefill logic */ }
    void run_decode(...) override  { /* your decode logic */ }
    void finalize(...) override    { /* detokenize */ }
    cudaStream_t get_stream() const override { return stream; }
};
```

Then add one line to `batch_executor.cpp`:
```cpp
case StrategyType::KV_CACHE:
    strategy = std::make_unique<pipeline::KVCacheEngine>(...);
```

Timing, metrics, and benchmarks work automatically — no other changes needed.

### Testing

- ✅ Full build passes (`cmake + make -j`)
- ✅ `gpt2_engine` produces correct output with accurate metrics
- ✅ `bench_performance` runs end-to-end
